### PR TITLE
Add gRPC connection to data service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ services:  # API Gateway (Traefik)
       - JWT_SECRET=tripify-secret-key-change-in-production
       - PORT=3000
       - GRPC_PORT=50051
+      - DATA_SERVICE_HOST=data-service
+      - DATA_SERVICE_PORT=50052
     depends_on:
       mongo:
         condition: service_healthy

--- a/services/api-node/src/grpc/clients/dataServiceClient.js
+++ b/services/api-node/src/grpc/clients/dataServiceClient.js
@@ -1,0 +1,28 @@
+import grpc from "@grpc/grpc-js";
+import protoLoader from "@grpc/proto-loader";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PROTO_PATH = path.join(__dirname, "../../../contracts/tripify.proto");
+
+const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
+
+const tripifyProto = grpc.loadPackageDefinition(packageDefinition).tripify.v1;
+
+const dataClient = new tripifyProto.DataService(
+  `${process.env.DATA_SERVICE_HOST || "data-service"}:${
+    process.env.DATA_SERVICE_PORT || 50052
+  }`,
+  grpc.credentials.createInsecure()
+);
+
+export default dataClient;

--- a/services/api-node/src/index.js
+++ b/services/api-node/src/index.js
@@ -17,10 +17,11 @@ import userRoutes from "./routes/users.js";
 import tripRoutes from "./routes/trips.js";
 import discoveryRoutes from "./routes/discovery.js";
 import recommendationRoutes from "./routes/recommendations.js";
+import dataRoutes from "./routes/data.js";
 
 
 // Import gRPC server
-// import GrpcServer from "./grpc/index.js";
+import GrpcServer from "./grpc/index.js";
 import consul from "./config/consul.js";
 
 // Load environment variables
@@ -85,6 +86,7 @@ app.use("/v1/users", userRoutes);
 app.use("/v1/trips", tripRoutes);
 app.use("/v1/discovery", discoveryRoutes);
 app.use("/v1/recommendations", recommendationRoutes);
+app.use("/v1/data", dataRoutes);
 
 // Catch-all for undefined routes
 app.all("*", (req, res) => {
@@ -139,10 +141,10 @@ const server = app.listen(PORT, async () => {
 });
 
 // Start gRPC server
-// const grpcServer = new GrpcServer();
-// grpcServer.start(GRPC_PORT).catch((error) => {
-//   console.error("Failed to start gRPC server:", error);
-// });
+const grpcServer = new GrpcServer();
+grpcServer.start(GRPC_PORT).catch((error) => {
+  console.error("Failed to start gRPC server:", error);
+});
 
 // Graceful shutdown
 const gracefulShutdown = async (signal) => {
@@ -153,12 +155,12 @@ const gracefulShutdown = async (signal) => {
     console.log("✅ HTTP server closed");
   });
   // Close gRPC server
-  // try {
-  //   await grpcServer.stop();
-  //   console.log("✅ gRPC server closed");
-  // } catch (error) {
-  //   console.error("❌ Error closing gRPC server:", error);
-  // }
+  try {
+    await grpcServer.stop();
+    console.log("✅ gRPC server closed");
+  } catch (error) {
+    console.error("❌ Error closing gRPC server:", error);
+  }
 
   // Close database connection
   try {

--- a/services/api-node/src/routes/data.js
+++ b/services/api-node/src/routes/data.js
@@ -1,0 +1,20 @@
+import express from "express";
+import { promisify } from "util";
+import dataClient from "../grpc/clients/dataServiceClient.js";
+
+const router = express.Router();
+
+const getWeather = promisify(dataClient.GetWeather.bind(dataClient));
+
+router.get("/weather", async (req, res) => {
+  try {
+    const { city = "Paris", country = "FR" } = req.query;
+    const result = await getWeather({ city, country_code: country });
+    res.json({ success: true, data: result });
+  } catch (error) {
+    console.error("Data service gRPC error:", error.message);
+    res.status(500).json({ success: false, message: "Failed to fetch weather" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- expose data service connection info in `docker-compose.yml`
- start the API's gRPC server
- add data service gRPC client and example route

## Testing
- `npm test --silent` *(fails: Exceeded timeout of 5000 ms for a hook)*

------
https://chatgpt.com/codex/tasks/task_e_684c4d1b8050832bac65288649751ea6